### PR TITLE
defer log message in guard authenticator

### DIFF
--- a/src/Symfony/Component/Security/Guard/Firewall/GuardAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Guard/Firewall/GuardAuthenticationListener.php
@@ -95,13 +95,13 @@ class GuardAuthenticationListener implements ListenerInterface
     {
         $request = $event->getRequest();
         try {
-            if (null !== $this->logger) {
-                $this->logger->debug('Calling getCredentials() on guard authenticator.', array('firewall_key' => $this->providerKey, 'authenticator' => \get_class($guardAuthenticator)));
-            }
-
             // abort the execution of the authenticator if it doesn't support the request
             if (!$guardAuthenticator->supports($request)) {
                 return;
+            }
+
+            if (null !== $this->logger) {
+                $this->logger->debug('Calling getCredentials() on guard authenticator.', array('firewall_key' => $this->providerKey, 'authenticator' => \get_class($guardAuthenticator)));
             }
 
             // allow the authenticator to fetch authentication info from the request


### PR DESCRIPTION
prevent an unneccessary log message if the guard authenticator does not support the current request

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This PR defers log messages about "getCredentials()" method calls if more than one guard authentication provider is used. The method is only called if the provider supports the request. The log message may be confusing during development.